### PR TITLE
Fix maxProperties in generated schemas

### DIFF
--- a/src/main/scala/util/JsonSchema.scala
+++ b/src/main/scala/util/JsonSchema.scala
@@ -76,7 +76,7 @@ object JsonSchema {
     override def toString: String = s""""maxItems":${value.toString}"""
   }
   case class JSA_maxProperties(value: Double) extends JsonSchemaStructure {
-    override def toString: String = s""""maxItems":${value.toString}"""
+    override def toString: String = s""""maxProperties":${value.toString}"""
   }
   case class JSA_additionalProperties(value: Boolean) extends JsonSchemaStructure {
     override def toString: String = s""""additionalProperties":${value.toString}"""


### PR DESCRIPTION
`maxProperties` is currently written in schemas as `maxItems`.
This changes to the correct name.